### PR TITLE
fix: kotlin sources

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -100,6 +100,7 @@ dependencies {
 
     modImplementation(libs.bundles.fabric)
 
+    implementation(libs.kotlin.stdlib)
     implementation(libs.repo) // included in sbapi, exposed through implementation
 
     includeModImplementationBundle(libs.bundles.sbapi)

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -39,6 +39,7 @@ minecraft = { module = "com.mojang:minecraft", version.ref = "minecraft" }
 loader = { module = "net.fabricmc:fabric-loader", version.ref = "loader" }
 fabric = { module = "net.fabricmc.fabric-api:fabric-api", version.ref = "fabric" }
 fabrickotlin = { module = "net.fabricmc:fabric-language-kotlin", version.ref = "fabrickotlin" }
+kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
 
 # Libs with mc version in artifact id
 skyblockapi = { module = "tech.thatgravyboat:skyblock-api-<mc_version>", version.ref = "skyblockapi" }


### PR DESCRIPTION
this should make it so that intellij actually has the sources for kotlin classes