### PR TITLE
fix: crafthelper on high gui scales

### DIFF
--- a/src/common/main/kotlin/me/owdding/skyocean/features/recipe/crafthelper/display/CraftHelperDisplay.kt
+++ b/src/common/main/kotlin/me/owdding/skyocean/features/recipe/crafthelper/display/CraftHelperDisplay.kt
@@ -56,7 +56,7 @@ object CraftHelperDisplay : MeowddingLogger by SkyOcean.featureLogger() {
         if (!LocationAPI.isOnSkyBlock) return
         if (event.screen !is AbstractContainerScreen<*>) return
 
-        val maxWidth = (event.screen as AbstractContainerScreenAccessor).leftPos - (MiscConfig.craftHelperMargin * 2)
+        val maxWidth = (event.screen as AbstractContainerScreenAccessor).leftPos - (CraftHelperConfig.margin * 2)
 
         val layout = LayoutFactory.empty() as ScalableFrameLayout
         lateinit var callback: (save: Boolean) -> Unit


### PR DESCRIPTION
<img width="875" height="532" alt="image" src="https://github.com/user-attachments/assets/99adaf97-6870-4708-9916-715d0a23a421" />

current issues (all ScaleableWidget issues):
- item doesnt scale down
- hover doesnt work when downscaled
- clicking on top row doesnt register until screen refresh (resize, reopen, etc)