### PR TITLE
Glacite Tunnels Retexturing additions + more

### DIFF
--- a/src/common/main/kotlin/me/owdding/skyocean/features/textures/GemstoneBlocks.kt
+++ b/src/common/main/kotlin/me/owdding/skyocean/features/textures/GemstoneBlocks.kt
@@ -1,6 +1,7 @@
 package me.owdding.skyocean.features.textures
 
 import me.owdding.ktmodules.Module
+import me.owdding.skyocean.SkyOcean.id
 import me.owdding.skyocean.config.features.mining.MiningRetexture
 import me.owdding.skyocean.events.RegisterFakeBlocksEvent
 import me.owdding.skyocean.utils.boundingboxes.DwarvenMinesBB
@@ -14,32 +15,59 @@ import tech.thatgravyboat.skyblockapi.api.location.SkyBlockIsland
 @Module
 object GemstoneBlocks : BlockRetexture() {
 
+    val RUBY = id("mining/gemstones/ruby")
+    val RUBY_PANE = id("mining/gemstones/ruby_pane") 
+    val AMBER = id("mining/gemstones/amber") 
+    val AMBER_PANE = id("mining/gemstones/amber_pane") 
+    val SAPPHIRE = id("mining/gemstones/sapphire") 
+    val SAPPHIRE_PANE = id("mining/gemstones/sapphire_pane") 
+    val JADE = id("mining/gemstones/jade")
+    val JADE_PANE = id("mining/gemstones/jade_pane") 
+    val AMETHYST = id("mining/gemstones/amethyst") 
+    val AMETHYST_PANE = id("mining/gemstones/amethyst_pane") 
+    val OPAL = id("mining/gemstones/opal") 
+    val OPAL_PANE = id("mining/gemstones/opal_pane")     
+    val TOPAZ = id("mining/gemstones/topaz")
+    val TOPAZ_PANE = id("mining/gemstones/topaz_pane") 
+    val JASPER = id("mining/gemstones/jasper") 
+    val JASPER_PANE = id("mining/gemstones/jasper_pane") 
+    val ONYX = id("mining/gemstones/onyx") 
+    val ONYX_PANE = id("mining/gemstones/onyx_pane")     
+    val AQUAMARINE = id("mining/gemstones/aquamarine")
+    val AQUAMARINE_PANE = id("mining/gemstones/aquamarine_pane") 
+    val CITRINE = id("mining/gemstones/citrine") 
+    val CITRINE_PANE = id("mining/gemstones/citrine_pane") 
+    val PERIDOT = id("mining/gemstones/peridot") 
+    val PERIDOT_PANE = id("mining/gemstones/peridot_pane")
+
+
+
     @Subscription
     fun registerFakeBlocks(event: RegisterFakeBlocksEvent) = with(event) {
-        register(Blocks.RED_STAINED_GLASS, "ruby")
-        register(Blocks.RED_STAINED_GLASS_PANE, "ruby_pane")
-        register(Blocks.ORANGE_STAINED_GLASS, "amber")
-        register(Blocks.ORANGE_STAINED_GLASS_PANE, "amber_pane")
-        register(Blocks.LIGHT_BLUE_STAINED_GLASS, "sapphire")
-        register(Blocks.LIGHT_BLUE_STAINED_GLASS_PANE, "sapphire_pane")
-        register(Blocks.LIME_STAINED_GLASS, "jade")
-        register(Blocks.LIME_STAINED_GLASS_PANE, "jade_pane")
-        register(Blocks.PURPLE_STAINED_GLASS, "amethyst")
-        register(Blocks.PURPLE_STAINED_GLASS_PANE, "amethyst_pane")
-        register(Blocks.WHITE_STAINED_GLASS, "opal", condition = ::opalCondition) // opal can only generate in mineshafts and crimson isle
-        register(Blocks.WHITE_STAINED_GLASS_PANE, "opal_pane", condition = ::opalCondition) // opal can only generate in mineshafts and crimson isle
-        register(Blocks.YELLOW_STAINED_GLASS, "topaz")
-        register(Blocks.YELLOW_STAINED_GLASS_PANE, "topaz_pane")
-        register(Blocks.MAGENTA_STAINED_GLASS, "jasper")
-        register(Blocks.MAGENTA_STAINED_GLASS_PANE, "jasper_pane")
-        register(Blocks.BLACK_STAINED_GLASS, "onyx")
-        register(Blocks.BLACK_STAINED_GLASS_PANE, "onyx_pane")
-        register(Blocks.BLUE_STAINED_GLASS, "aquamarine")
-        register(Blocks.BLUE_STAINED_GLASS_PANE, "aquamarine_pane")
-        register(Blocks.BROWN_STAINED_GLASS, "citrine")
-        register(Blocks.BROWN_STAINED_GLASS_PANE, "citrine_pane")
-        register(Blocks.GREEN_STAINED_GLASS, "peridot")
-        register(Blocks.GREEN_STAINED_GLASS_PANE, "peridot_pane")
+        register(Blocks.RED_STAINED_GLASS, RUBY)
+        register(Blocks.RED_STAINED_GLASS_PANE, RUBY_PANE)
+        register(Blocks.ORANGE_STAINED_GLASS, AMBER)
+        register(Blocks.ORANGE_STAINED_GLASS_PANE, AMBER_PANE)
+        register(Blocks.LIGHT_BLUE_STAINED_GLASS, SAPPHIRE)
+        register(Blocks.LIGHT_BLUE_STAINED_GLASS_PANE, SAPPHIRE_PANE)
+        register(Blocks.LIME_STAINED_GLASS, JADE)
+        register(Blocks.LIME_STAINED_GLASS_PANE, JADE_PANE)
+        register(Blocks.PURPLE_STAINED_GLASS, AMETHYST)
+        register(Blocks.PURPLE_STAINED_GLASS_PANE, AMETHYST_PANE)
+        register(Blocks.WHITE_STAINED_GLASS, OPAL, condition = ::opalCondition) // opal can only generate in mineshafts and crimson isle
+        register(Blocks.WHITE_STAINED_GLASS_PANE, OPAL_PANE, condition = ::opalCondition) // opal can only generate in mineshafts and crimson isle
+        register(Blocks.YELLOW_STAINED_GLASS, TOPAZ)
+        register(Blocks.YELLOW_STAINED_GLASS_PANE, TOPAZ_PANE)
+        register(Blocks.MAGENTA_STAINED_GLASS, JASPER)
+        register(Blocks.MAGENTA_STAINED_GLASS_PANE, JASPER_PANE)
+        register(Blocks.BLACK_STAINED_GLASS, ONYX)
+        register(Blocks.BLACK_STAINED_GLASS_PANE, ONYX_PANE)
+        register(Blocks.BLUE_STAINED_GLASS, AQUAMARINE)
+        register(Blocks.BLUE_STAINED_GLASS_PANE, AQUAMARINE_PANE)
+        register(Blocks.BROWN_STAINED_GLASS, CITRINE)
+        register(Blocks.BROWN_STAINED_GLASS_PANE, CITRINE_PANE)
+        register(Blocks.GREEN_STAINED_GLASS, PERIDOT)
+        register(Blocks.GREEN_STAINED_GLASS_PANE, PERIDOT_PANE)
     }
 
     fun opalCondition(blockState: BlockState, blockPos: BlockPos): Boolean {

--- a/src/common/main/kotlin/me/owdding/skyocean/features/textures/GlaciteBlocks.kt
+++ b/src/common/main/kotlin/me/owdding/skyocean/features/textures/GlaciteBlocks.kt
@@ -20,6 +20,14 @@ object GlaciteBlocks : BlockRetexture() {
     val GLACITE_SNOW_BLOCK = id("mining/glacite/glacite_snow_block")
     val GLACITE_HARD_STONE = id("mining/glacite/glacite_hard_stone")
     val GLACITE_HARD_STONE_WOOL = id("mining/glacite/glacite_hard_stone_wool")
+    val LOW_TIER_TUNGSTEN = id("mining/glacite/low_tier_tungsten")
+    val LOW_TIER_TUNGSTEN_STAIRS = id("mining/glacite/low_tier_tungsten_stairs")
+    val LOW_TIER_TUNGSTEN_SLAB = id("mining/glacite/low_tier_tungsten_stairs")
+    val HIGH_TIER_TUNGSTEN = id("mining/glacite/high_tier_tungsten")
+    val LOW_TIER_UMBER = id("mining/glacite/low_tier_umber")
+    val MID_TIER_UMBER = id("mining/glacite/mid_tier_umber")
+    val HIGH_TIER_UMBER = id("mining/glacite/high_tier_umber")
+
 
     @Subscription
     fun registerFakeBlocks(event: RegisterFakeBlocksEvent) = with(event) {
@@ -31,6 +39,22 @@ object GlaciteBlocks : BlockRetexture() {
             return@registerMultiple defaultCondition(state, pos)
         }
         register(Blocks.LIGHT_GRAY_WOOL, GLACITE_HARD_STONE_WOOL, CrystalHollowBlocks.HARDSTONE)
+        registerMultiple(Blocks.INFESTED_COBBLESTONE, Blocks.COBBLESTONE, id = LOW_TIER_TUNGSTEN) { state, pos ->
+            if (state.block == Blocks.COBBLESTONE && !SkyBlockIsland.MINESHAFT.inIsland()) return@registerMultiple false
+            return@registerMultiple defaultCondition(state, pos)
+        }
+        register(Blocks.COBBLESTONE_STAIRS, id = LOW_TIER_TUNGSTEN_STAIRS) { state, pos ->
+            if (state.block == Blocks.COBBLESTONE_STAIRS && !SkyBlockIsland.MINESHAFT.inIsland()) return@register false
+            return@register defaultCondition(state, pos)
+        }
+        register(Blocks.COBBLESTONE_SLAB, id = LOW_TIER_TUNGSTEN_SLAB) { state, pos ->
+            if (state.block == Blocks.COBBLESTONE_SLAB && !SkyBlockIsland.MINESHAFT.inIsland()) return@register false
+            return@register defaultCondition(state, pos)
+        }
+        register(Blocks.CLAY, HIGH_TIER_TUNGSTEN)
+        register(Blocks.TERRACOTTA, LOW_TIER_UMBER)
+        register(Blocks.BROWN_TERRACOTTA, MID_TIER_UMBER)
+        register(Blocks.SMOOTH_RED_SANDSTONE, HIGH_TIER_UMBER)
     }
 
     override fun defaultCondition(blockState: BlockState, blockPos: BlockPos): Boolean {

--- a/src/common/main/kotlin/me/owdding/skyocean/features/textures/GlaciteBlocks.kt
+++ b/src/common/main/kotlin/me/owdding/skyocean/features/textures/GlaciteBlocks.kt
@@ -19,6 +19,7 @@ object GlaciteBlocks : BlockRetexture() {
     val GLACITE_SNOW = id("mining/glacite/glacite_snow")
     val GLACITE_SNOW_BLOCK = id("mining/glacite/glacite_snow_block")
     val GLACITE_HARD_STONE = id("mining/glacite/glacite_hard_stone")
+    val GLACITE_HARD_STONE_CAMPFIRE_MINESHAFT = id("mining/glacite/glacite_hard_stone_campfire")
     val GLACITE_HARD_STONE_WOOL = id("mining/glacite/glacite_hard_stone_wool")
     val LOW_TIER_TUNGSTEN = id("mining/glacite/low_tier_tungsten")
     val LOW_TIER_TUNGSTEN_MINESHAFT = id("mining/glacite/low_tier_tungsten_mineshaft")
@@ -35,10 +36,8 @@ object GlaciteBlocks : BlockRetexture() {
         register(Blocks.SNOW, GLACITE_SNOW)
         register(Blocks.SNOW_BLOCK, GLACITE_SNOW_BLOCK)
         register(Blocks.PACKED_ICE, GLACITE_BLOCK)
-        registerMultiple(Blocks.INFESTED_STONE, Blocks.STONE, id = GLACITE_HARD_STONE) { state, pos ->
-            if (state.block == Blocks.STONE && !SkyBlockIsland.MINESHAFT.inIsland()) return@registerMultiple false
-            return@registerMultiple defaultCondition(state, pos)
-        }
+        register(Blocks.INFESTED_STONE, id = GLACITE_HARD_STONE)
+        register(Blocks.STONE, GLACITE_HARD_STONE_CAMPFIRE_MINESHAFT, GLACITE_HARD_STONE)
         register(Blocks.LIGHT_GRAY_WOOL, GLACITE_HARD_STONE_WOOL, CrystalHollowBlocks.HARDSTONE)
         register(Blocks.INFESTED_COBBLESTONE, LOW_TIER_TUNGSTEN)
         register(Blocks.COBBLESTONE, id = LOW_TIER_TUNGSTEN_MINESHAFT, LOW_TIER_TUNGSTEN) { state, pos ->

--- a/src/common/main/kotlin/me/owdding/skyocean/features/textures/GlaciteBlocks.kt
+++ b/src/common/main/kotlin/me/owdding/skyocean/features/textures/GlaciteBlocks.kt
@@ -21,8 +21,9 @@ object GlaciteBlocks : BlockRetexture() {
     val GLACITE_HARD_STONE = id("mining/glacite/glacite_hard_stone")
     val GLACITE_HARD_STONE_WOOL = id("mining/glacite/glacite_hard_stone_wool")
     val LOW_TIER_TUNGSTEN = id("mining/glacite/low_tier_tungsten")
+    val LOW_TIER_TUNGSTEN_MINESHAFT = id("mining/glacite/low_tier_tungsten_mineshaft")
     val LOW_TIER_TUNGSTEN_STAIRS = id("mining/glacite/low_tier_tungsten_stairs")
-    val LOW_TIER_TUNGSTEN_SLAB = id("mining/glacite/low_tier_tungsten_stairs")
+    val LOW_TIER_TUNGSTEN_SLAB = id("mining/glacite/low_tier_tungsten_slab")
     val HIGH_TIER_TUNGSTEN = id("mining/glacite/high_tier_tungsten")
     val LOW_TIER_UMBER = id("mining/glacite/low_tier_umber")
     val MID_TIER_UMBER = id("mining/glacite/mid_tier_umber")
@@ -34,14 +35,15 @@ object GlaciteBlocks : BlockRetexture() {
         register(Blocks.SNOW, GLACITE_SNOW)
         register(Blocks.SNOW_BLOCK, GLACITE_SNOW_BLOCK)
         register(Blocks.PACKED_ICE, GLACITE_BLOCK)
-        registerMultiple(Blocks.INFESTED_STONE, Blocks.STONE, id = GLACITE_HARD_STONE, parent = CrystalHollowBlocks.HARDSTONE) { state, pos ->
+        registerMultiple(Blocks.INFESTED_STONE, Blocks.STONE, id = GLACITE_HARD_STONE) { state, pos ->
             if (state.block == Blocks.STONE && !SkyBlockIsland.MINESHAFT.inIsland()) return@registerMultiple false
             return@registerMultiple defaultCondition(state, pos)
         }
         register(Blocks.LIGHT_GRAY_WOOL, GLACITE_HARD_STONE_WOOL, CrystalHollowBlocks.HARDSTONE)
-        registerMultiple(Blocks.INFESTED_COBBLESTONE, Blocks.COBBLESTONE, id = LOW_TIER_TUNGSTEN) { state, pos ->
-            if (state.block == Blocks.COBBLESTONE && !SkyBlockIsland.MINESHAFT.inIsland()) return@registerMultiple false
-            return@registerMultiple defaultCondition(state, pos)
+        register(Blocks.INFESTED_COBBLESTONE, LOW_TIER_TUNGSTEN)
+        register(Blocks.COBBLESTONE, id = LOW_TIER_TUNGSTEN_MINESHAFT, LOW_TIER_TUNGSTEN) { state, pos ->
+            if (state.block == Blocks.COBBLESTONE && !SkyBlockIsland.MINESHAFT.inIsland()) return@register false
+            return@register defaultCondition(state, pos)
         }
         register(Blocks.COBBLESTONE_STAIRS, id = LOW_TIER_TUNGSTEN_STAIRS) { state, pos ->
             if (state.block == Blocks.COBBLESTONE_STAIRS && !SkyBlockIsland.MINESHAFT.inIsland()) return@register false

--- a/src/common/main/kotlin/me/owdding/skyocean/features/textures/GlaciteBlocks.kt
+++ b/src/common/main/kotlin/me/owdding/skyocean/features/textures/GlaciteBlocks.kt
@@ -19,7 +19,7 @@ object GlaciteBlocks : BlockRetexture() {
     val GLACITE_SNOW = id("mining/glacite/glacite_snow")
     val GLACITE_SNOW_BLOCK = id("mining/glacite/glacite_snow_block")
     val GLACITE_HARD_STONE = id("mining/glacite/glacite_hard_stone")
-    val GLACITE_HARD_STONE_WOOL = id("glacite/glacite_hard_stone_wool")
+    val GLACITE_HARD_STONE_WOOL = id("mining/glacite/glacite_hard_stone_wool")
 
     @Subscription
     fun registerFakeBlocks(event: RegisterFakeBlocksEvent) = with(event) {

--- a/src/common/main/kotlin/me/owdding/skyocean/features/textures/GlaciteBlocks.kt
+++ b/src/common/main/kotlin/me/owdding/skyocean/features/textures/GlaciteBlocks.kt
@@ -1,6 +1,7 @@
 package me.owdding.skyocean.features.textures
 
 import me.owdding.ktmodules.Module
+import me.owdding.skyocean.SkyOcean.id
 import me.owdding.skyocean.config.features.mining.MiningRetexture
 import me.owdding.skyocean.events.RegisterFakeBlocksEvent
 import me.owdding.skyocean.utils.boundingboxes.DwarvenMinesBB
@@ -14,16 +15,22 @@ import tech.thatgravyboat.skyblockapi.api.location.SkyBlockIsland
 @Module
 object GlaciteBlocks : BlockRetexture() {
 
+    val GLACITE_BLOCK = id("mining/glacite/glacite_block")
+    val GLACITE_SNOW = id("mining/glacite/glacite_snow")
+    val GLACITE_SNOW_BLOCK = id("mining/glacite/glacite_snow_block")
+    val GLACITE_HARD_STONE = id("mining/glacite/glacite_hard_stone")
+    val GLACITE_HARD_STONE_WOOL = id("glacite/glacite_hard_stone_wool")
+
     @Subscription
     fun registerFakeBlocks(event: RegisterFakeBlocksEvent) = with(event) {
-        register(Blocks.SNOW, "glacite_snow")
-        register(Blocks.SNOW_BLOCK, "glacite_snow_block")
-        register(Blocks.PACKED_ICE, "glacite")
-        registerMultiple(Blocks.INFESTED_STONE, Blocks.STONE, id = "glacite_hard_stone", parent = CrystalHollowBlocks.HARDSTONE) { state, pos ->
+        register(Blocks.SNOW, GLACITE_SNOW)
+        register(Blocks.SNOW_BLOCK, GLACITE_SNOW_BLOCK)
+        register(Blocks.PACKED_ICE, GLACITE_BLOCK)
+        registerMultiple(Blocks.INFESTED_STONE, Blocks.STONE, id = GLACITE_HARD_STONE, parent = CrystalHollowBlocks.HARDSTONE) { state, pos ->
             if (state.block == Blocks.STONE && !SkyBlockIsland.MINESHAFT.inIsland()) return@registerMultiple false
             return@registerMultiple defaultCondition(state, pos)
         }
-        register(Blocks.LIGHT_GRAY_WOOL, "glacite_hard_stone_wool", CrystalHollowBlocks.HARDSTONE)
+        register(Blocks.LIGHT_GRAY_WOOL, GLACITE_HARD_STONE_WOOL, CrystalHollowBlocks.HARDSTONE)
     }
 
     override fun defaultCondition(blockState: BlockState, blockPos: BlockPos): Boolean {

--- a/src/common/main/kotlin/me/owdding/skyocean/features/textures/MistBlocks.kt
+++ b/src/common/main/kotlin/me/owdding/skyocean/features/textures/MistBlocks.kt
@@ -15,14 +15,14 @@ import tech.thatgravyboat.skyblockapi.api.location.SkyBlockIsland
 object MistBlocks : BlockRetexture() {
 
     val MIST_SNOW = id("mining/mist/mist_snow")
-    val MIST_SNOW_BLOCK = id("mining/mist/mist_snow")
-    val MIST_GLASS = id("mining/mist/mist_snow")
-    val MIST_GLASS_SECONDARY = id("mining/mist/mist_snow")
-    val MIST_CLAY = id("mining/mist/mist_snow")
-    val MIST_ICE = id("mining/mist/mist_snow")
-    val MIST_CARPET = id("mining/mist/mist_snow")
-    val MIST_LIGHT_BLUE_GLASS_PANE = id("mist/mist_snow")
-    val MIST_BLUE_GLASS_PANE = id("mist/mist_snow")
+    val MIST_SNOW_BLOCK = id("mining/mist/mist_snow_block")
+    val MIST_GLASS = id("mining/mist/mist_glass")
+    val MIST_GLASS_SECONDARY = id("mining/mist/mist_glass_secondary")
+    val MIST_CLAY = id("mining/mist/mist_clay")
+    val MIST_ICE = id("mining/mist/mist_ice")
+    val MIST_CARPET = id("mining/mist/mist_carpet")
+    val MIST_LIGHT_BLUE_GLASS_PANE = id("mining/mist/mist_light_blue_glass_pane")
+    val MIST_BLUE_GLASS_PANE = id("mining/mist/mist_blue_glass_pane")
 
 
     @Subscription

--- a/src/common/main/kotlin/me/owdding/skyocean/features/textures/MistBlocks.kt
+++ b/src/common/main/kotlin/me/owdding/skyocean/features/textures/MistBlocks.kt
@@ -1,6 +1,7 @@
 package me.owdding.skyocean.features.textures
 
 import me.owdding.ktmodules.Module
+import me.owdding.skyocean.SkyOcean.id
 import me.owdding.skyocean.config.features.mining.MiningRetexture
 import me.owdding.skyocean.events.RegisterFakeBlocksEvent
 import me.owdding.skyocean.utils.boundingboxes.DwarvenMinesBB
@@ -13,17 +14,28 @@ import tech.thatgravyboat.skyblockapi.api.location.SkyBlockIsland
 @Module
 object MistBlocks : BlockRetexture() {
 
+    val MIST_SNOW = id("mining/mist/mist_snow")
+    val MIST_SNOW_BLOCK = id("mining/mist/mist_snow")
+    val MIST_GLASS = id("mining/mist/mist_snow")
+    val MIST_GLASS_SECONDARY = id("mining/mist/mist_snow")
+    val MIST_CLAY = id("mining/mist/mist_snow")
+    val MIST_ICE = id("mining/mist/mist_snow")
+    val MIST_CARPET = id("mining/mist/mist_snow")
+    val MIST_LIGHT_BLUE_GLASS_PANE = id("mist/mist_snow")
+    val MIST_BLUE_GLASS_PANE = id("mist/mist_snow")
+
+
     @Subscription
     fun registerFakeBlocks(event: RegisterFakeBlocksEvent) = with(event) {
-        register(Blocks.SNOW, "mist_snow")
-        register(Blocks.SNOW_BLOCK, "mist_snow_block")
-        register(Blocks.WHITE_STAINED_GLASS, "mist_glass")
-        register(Blocks.CLAY, "mist_clay")
-        register(Blocks.ICE, "mist_ice")
-        register(Blocks.LIGHT_BLUE_STAINED_GLASS, "mist_glass_secondary")
-        register(Blocks.WHITE_CARPET, "mist_carpet")
-        register(Blocks.LIGHT_BLUE_STAINED_GLASS_PANE, "mist_light_blue_glass_pane")
-        register(Blocks.BLUE_STAINED_GLASS_PANE, "mist_blue_glass_pane")
+        register(Blocks.SNOW, MIST_SNOW)
+        register(Blocks.SNOW_BLOCK, MIST_SNOW_BLOCK)
+        register(Blocks.WHITE_STAINED_GLASS, MIST_GLASS)
+        register(Blocks.CLAY, MIST_CLAY)
+        register(Blocks.ICE, MIST_ICE)
+        register(Blocks.LIGHT_BLUE_STAINED_GLASS, MIST_GLASS_SECONDARY)
+        register(Blocks.WHITE_CARPET, MIST_CARPET)
+        register(Blocks.LIGHT_BLUE_STAINED_GLASS_PANE, MIST_LIGHT_BLUE_GLASS_PANE)
+        register(Blocks.BLUE_STAINED_GLASS_PANE, MIST_BLUE_GLASS_PANE)
     }
 
     override fun defaultCondition(blockState: BlockState, blockPos: BlockPos): Boolean {

--- a/src/common/main/kotlin/me/owdding/skyocean/utils/boundingboxes/DwarvenMinesBB.kt
+++ b/src/common/main/kotlin/me/owdding/skyocean/utils/boundingboxes/DwarvenMinesBB.kt
@@ -6,7 +6,11 @@ import net.minecraft.world.level.levelgen.structure.BoundingBox
 object DwarvenMinesBB {
     private fun create(pos1: Vec3i, pos2: Vec3i): BoundingBox = BoundingBox.fromCorners(pos1, pos2)
 
-    val GLACITE_TUNNELS = create(Vec3i(-128, 112, 184), Vec3i(127, 174, 479))
+    val GLACITE_TUNNELS = Octree(
+        create(Vec3i(-128, 112, 198), Vec3i(127, 174, 479)),
+        create(Vec3i(-19, 127, 182), Vec3i(26, 166, 197)),
+    )
+    
     val MIST = Octree(
         create(Vec3i(-73, 88, 162), Vec3i(181, 64, 34)),
         create(Vec3i(175, 89, 99), Vec3i(106, 117, 28)),

--- a/src/lang/en_us.json
+++ b/src/lang/en_us.json
@@ -74,7 +74,7 @@
         "glacite": {
           "@value": "Retexture Glacite Tunnel blocks",
           "desc": [
-            "Allows resource packs to change the appearance of glacite tunnel blocks."
+            "Allows resource packs to change the appearance of glacite tunnel blocks & dwarven metals."
           ]
         },
         "mist": {


### PR DESCRIPTION
Multiple Changes in this one pull request:

1. Added support for Umber & Tungsten retexturing to the glacite tunnels retexture feature
2. Updated the glacite, mist and gemstone resource locations to follow the same structure as the crystal hollows one
3. Change the area of the Glacite Tunnels so that it can't hit other zones outside the Glacite Tunnels
4. Fix a bug where some of the stone in the base camp went untextured due to some of the blocks being stone instead of infested stone (why would Hypixel do this?)