### PR TITLE
feat: huntaxe and toolbox item sources + disallowed sources

### DIFF
--- a/src/common/main/kotlin/me/owdding/skyocean/config/features/misc/MiscConfig.kt
+++ b/src/common/main/kotlin/me/owdding/skyocean/config/features/misc/MiscConfig.kt
@@ -90,8 +90,8 @@ object MiscConfig : CategoryKt("misc") {
         translation = "skyocean.config.misc.crafthelper.disableRootItems"
     }
 
-    var craftHelperSources by select(*ItemSources.entries.toTypedArray()) {
-        translation = "skyocean.config.misc.itemSources"
+    var disallowedCraftHelperSources by select<ItemSources> {
+        translation = "skyocean.config.misc.crafthelper.disallowedItemSources"
     }
 
     var craftHelperPosition by enum(CraftHelperLocation.LEFT_OF_INVENTORY) {

--- a/src/common/main/kotlin/me/owdding/skyocean/data/profile/GalateaItemStorage.kt
+++ b/src/common/main/kotlin/me/owdding/skyocean/data/profile/GalateaItemStorage.kt
@@ -1,0 +1,53 @@
+package me.owdding.skyocean.data.profile
+
+import me.owdding.ktcodecs.GenerateCodec
+import me.owdding.ktmodules.Module
+import me.owdding.skyocean.generated.SkyOceanCodecs
+import me.owdding.skyocean.utils.Utils.containerItems
+import me.owdding.skyocean.utils.storage.ProfileStorage
+import net.minecraft.world.item.ItemStack
+import tech.thatgravyboat.skyblockapi.api.events.base.Subscription
+import tech.thatgravyboat.skyblockapi.api.events.base.predicates.OnlyOnSkyBlock
+import tech.thatgravyboat.skyblockapi.api.events.screen.InventoryChangeEvent
+import tech.thatgravyboat.skyblockapi.utils.extentions.getSkyBlockId
+
+@Module
+object GalateaItemStorage {
+    private val storage: ProfileStorage<GalateaItems> = ProfileStorage(
+        defaultData = { GalateaItems.DEFAULT },
+        fileName = "galatea_items",
+        codec = { SkyOceanCodecs.GalateaItemsCodec.codec() },
+    )
+
+    val data get() = storage.get()
+
+    @Subscription()
+    @OnlyOnSkyBlock
+    private fun InventoryChangeEvent.onInventoryChange() {
+        val items = inventory.containerItems()
+        when {
+            title.contains("Huntaxe") -> {
+                val huntaxeItem = items.firstOrNull { it.getSkyBlockId() != null }
+                storage.get()?.huntaxeItem = huntaxeItem
+                storage.save()
+            }
+
+            title.contains("Hunting Toolkit") -> {
+                val toolkitItems =
+                    items.filter { it.getSkyBlockId() != null && it.getSkyBlockId() != "HUNTING_TOOLKIT" }
+                storage.get()?.toolkitItems = toolkitItems
+                storage.save()
+            }
+        }
+    }
+}
+
+@GenerateCodec
+data class GalateaItems(
+    var huntaxeItem: ItemStack?,
+    var toolkitItems: List<ItemStack>,
+) {
+    companion object {
+        val DEFAULT = GalateaItems(null, emptyList())
+    }
+}

--- a/src/common/main/kotlin/me/owdding/skyocean/features/item/sources/GalateaSources.kt
+++ b/src/common/main/kotlin/me/owdding/skyocean/features/item/sources/GalateaSources.kt
@@ -1,0 +1,80 @@
+package me.owdding.skyocean.features.item.sources
+
+import me.owdding.skyocean.data.profile.GalateaItemStorage
+import me.owdding.skyocean.features.item.sources.system.ParentItemContext
+import me.owdding.skyocean.features.item.sources.system.SimpleTrackedItem
+import net.minecraft.network.chat.Component
+import tech.thatgravyboat.skyblockapi.utils.extentions.getSkyBlockId
+import tech.thatgravyboat.skyblockapi.utils.text.TextColor
+import tech.thatgravyboat.skyblockapi.utils.text.TextStyle.color
+
+private val huntaxeIds = listOf(
+    "VENATOR_GENESIS",
+    "SILVA_DOMINUS",
+    "CURSUS_FERAE",
+    "APEX_PRAEDATOR",
+    "NEX_TITANUM",
+)
+
+object HuntaxeItemSource : ItemSource {
+    override val type = ItemSources.HUNTAXE
+
+    override fun getAll(): List<SimpleTrackedItem> = emptyList()
+
+    override fun postProcess(items: List<SimpleTrackedItem>): List<SimpleTrackedItem> {
+        return items.filter { (itemStack) -> itemStack.getSkyBlockId() in huntaxeIds }.mapNotNull { item ->
+            GalateaItemStorage.data?.huntaxeItem?.let {
+                SimpleTrackedItem(it, HuntaxeItemContext(item))
+            }
+        }
+    }
+}
+
+data class HuntaxeItemContext(override val parent: SimpleTrackedItem) : ParentItemContext(parent) {
+    override val source: ItemSources = ItemSources.HUNTAXE
+
+    override fun collectLines(): List<Component> = build {
+        add("Contained in ") {
+            append(parent.itemStack.hoverName)
+            append("!")
+            color = TextColor.GRAY
+        }
+        lines().addAll(parent.context.collectLines())
+    }
+
+    override fun open() {
+        parent.context.open()
+    }
+}
+
+
+object ToolkitItemSource : ItemSource {
+    override val type = ItemSources.TOOLKIT
+
+    override fun getAll(): List<SimpleTrackedItem> = emptyList()
+
+    override fun postProcess(items: List<SimpleTrackedItem>): List<SimpleTrackedItem> {
+        return items.filter { (itemStack) -> itemStack.getSkyBlockId()?.contains("HUNTING_TOOLKIT", true) == true }.flatMap { item ->
+            GalateaItemStorage.data?.toolkitItems?.map { SimpleTrackedItem(it, ToolkitItemContext(item)) } ?: emptyList()
+        }
+    }
+}
+
+data class ToolkitItemContext(override val parent: SimpleTrackedItem) : ParentItemContext(parent) {
+    override val source: ItemSources = ItemSources.TOOLKIT
+
+    override fun collectLines(): List<Component> = build {
+        add("Contained in ") {
+            append(parent.itemStack.hoverName)
+            append("!")
+            color = TextColor.GRAY
+        }
+        lines().addAll(parent.context.collectLines())
+    }
+
+    override fun open() {
+        parent.context.open()
+    }
+}
+
+

--- a/src/common/main/kotlin/me/owdding/skyocean/features/item/sources/ItemSource.kt
+++ b/src/common/main/kotlin/me/owdding/skyocean/features/item/sources/ItemSource.kt
@@ -29,6 +29,8 @@ enum class ItemSources(val itemSource: ItemSource?) {
     RIFT(RiftItemSource),
     DRILL_UPGRADE(DrillUpgradeItemSource),
     ROD_UPGRADE(RodUpgradesItemSource),
+    HUNTAXE(HuntaxeItemSource),
+    TOOLKIT(ToolkitItemSource)
     ;
     // todo SACK_OF_SACKS(TODO()),
     // todo POTION_BAG(TODO()),

--- a/src/common/main/kotlin/me/owdding/skyocean/features/recipe/crafthelper/display/CraftHelperDisplay.kt
+++ b/src/common/main/kotlin/me/owdding/skyocean/features/recipe/crafthelper/display/CraftHelperDisplay.kt
@@ -17,6 +17,7 @@ import me.owdding.skyocean.data.profile.CraftHelperStorage
 import me.owdding.skyocean.events.RegisterSkyOceanCommandEvent
 import me.owdding.skyocean.features.item.search.screen.ItemSearchScreen.asScrollable
 import me.owdding.skyocean.features.item.search.screen.ItemSearchScreen.withoutTooltipDelay
+import me.owdding.skyocean.features.item.sources.ItemSources
 import me.owdding.skyocean.features.recipe.ItemLikeIngredient
 import me.owdding.skyocean.features.recipe.SimpleRecipeApi.getBestRecipe
 import me.owdding.skyocean.features.recipe.crafthelper.ContextAwareRecipeTree
@@ -164,7 +165,8 @@ object CraftHelperDisplay {
     }
 
     private fun visualize(tree: ContextAwareRecipeTree, output: ItemLikeIngredient, callback: () -> ((save: Boolean) -> Unit)): AbstractWidget {
-        val tracker = ItemTracker(MiscConfig.craftHelperSources.toList())
+        val sources = ItemSources.entries - MiscConfig.disallowedCraftHelperSources.toList()
+        val tracker = ItemTracker(sources)
         val callback = callback()
 
         return LayoutFactory.vertical(2) {

--- a/src/lang/en_us.json
+++ b/src/lang/en_us.json
@@ -297,9 +297,9 @@
           "@value": "Disable tracking for target",
           "desc": "Prevents the craft helper from showing any progress for the root node, making it simpler for certain items."
         },
-        "itemSources": {
-          "@value": "Allowed item sources",
-          "desc": "Select sources from which the craft helper can count items"
+        "disallowedItemSources": {
+          "@value": "Disallowed item sources",
+          "desc": "Select sources from which the craft helper will ignore."
         },
         "position": {
           "@value": "Position",


### PR DESCRIPTION
made crafthelper itemsources from a whitelist into a blacklist to make it easier to maintain for the future (so we dont need config fixes for every time we add a new item source)