### PR TITLE
Fixed Inventory Buttons behaving incorrectly on 1.21.8

### DIFF
--- a/src/common/main/java/me/owdding/skyocean/mixins/AbstractContainerScreenMixin.java
+++ b/src/common/main/java/me/owdding/skyocean/mixins/AbstractContainerScreenMixin.java
@@ -18,6 +18,6 @@ public class AbstractContainerScreenMixin {
         )
     )
     public void onBackgroundDrawEnd(GuiGraphics graphics, int mouseX, int mouseY, float delta, CallbackInfo ci) {
-        InvButtons.INSTANCE.onScreenBackground((AbstractContainerScreen<?>) (Object) this, graphics, mouseX, mouseY, delta);
+        InvButtons.INSTANCE.onScreenBackground((AbstractContainerScreen<?>) (Object) this, graphics);
     }
 }

--- a/src/common/main/java/me/owdding/skyocean/mixins/AbstractContainerScreenMixin.java
+++ b/src/common/main/java/me/owdding/skyocean/mixins/AbstractContainerScreenMixin.java
@@ -18,6 +18,6 @@ public class AbstractContainerScreenMixin {
         )
     )
     public void onBackgroundDrawEnd(GuiGraphics graphics, int mouseX, int mouseY, float delta, CallbackInfo ci) {
-        InvButtons.INSTANCE.onScreenBackground((AbstractContainerScreen<?>) (Object) this, graphics);
+        InvButtons.INSTANCE.onScreenBackgroundAfter((AbstractContainerScreen<?>) (Object) this, graphics);
     }
 }

--- a/src/common/main/java/me/owdding/skyocean/mixins/AbstractContainerScreenMixin.java
+++ b/src/common/main/java/me/owdding/skyocean/mixins/AbstractContainerScreenMixin.java
@@ -1,0 +1,23 @@
+package me.owdding.skyocean.mixins;
+
+import me.owdding.skyocean.features.inventory.buttons.InvButtons;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(AbstractContainerScreen.class)
+public class AbstractContainerScreenMixin {
+    @Inject(
+        method = "renderBackground",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/client/gui/screens/inventory/AbstractContainerScreen;renderBg(Lnet/minecraft/client/gui/GuiGraphics;FII)V"
+        )
+    )
+    public void onBackgroundDrawEnd(GuiGraphics graphics, int mouseX, int mouseY, float delta, CallbackInfo ci) {
+        InvButtons.INSTANCE.onScreenBackground((AbstractContainerScreen<?>) (Object) this, graphics, mouseX, mouseY, delta);
+    }
+}

--- a/src/common/main/kotlin/me/owdding/skyocean/features/inventory/buttons/InvButton.kt
+++ b/src/common/main/kotlin/me/owdding/skyocean/features/inventory/buttons/InvButton.kt
@@ -33,14 +33,19 @@ class InvButton(
                 SELECTED_TOP_TABS[rowIndex]
             }
             renderPrevious(graphics, mouseX, mouseY, partialTicks, sprite)
-            val itemX = baseWidth / 2 - 8 + this@InvButton.x
-            val itemY = if (bottom) {
-                baseHeight + this@InvButton.y - (baseWidth / 2) - 8
-            } else {
-                baseWidth / 2 - 8 + this@InvButton.y
-            }
-            graphics.renderItem(button.itemStack, itemX, itemY)
+
         }
+    }
+
+    fun renderItem(graphics: GuiGraphics) {
+        val itemX = baseWidth / 2 - 8 + this@InvButton.x
+        val itemY = if (bottom) {
+            baseHeight + this@InvButton.y - (baseWidth / 2) - 8
+        } else {
+            baseWidth / 2 - 8 + this@InvButton.y
+        }
+        graphics.renderItem(button.itemStack, itemX, itemY)
+
     }
 
     override fun renderWidget(graphics: GuiGraphics, mouseX: Int, mouseY: Int, partialTick: Float) {
@@ -67,9 +72,10 @@ class InvButton(
     fun renderPrevious(graphics: GuiGraphics, mouseX: Int, mouseY: Int, partialTick: Float, sprite: ResourceLocation) {
         graphics.drawSprite(
             sprite,
-            this.x, this.y,
-            baseWidth, baseHeight,
-            -1,
+            this.x,
+            this.y,
+            baseWidth,
+            baseHeight,
         )
 
         WidgetRenderer.empty<Button>().render(graphics, WidgetRendererContext(this, mouseX, mouseY), partialTick)
@@ -78,5 +84,7 @@ class InvButton(
     companion object {
         val SELECTED_TOP_TABS = Array(7) { minecraft("container/creative_inventory/tab_top_selected_${it + 1}") }
         val SELECTED_BOTTOM_TABS = Array(7) { minecraft("container/creative_inventory/tab_bottom_selected_${it + 1}") }
+        val UNSELECTED_TOP_TABS = Array(7) { minecraft("container/creative_inventory/tab_top_unselected_${it + 1}") }
+        val UNSELECTED_BOTTOM_TABS = Array(7) { minecraft("container/creative_inventory/tab_bottom_unselected_${it + 1}") }
     }
 }

--- a/src/common/main/kotlin/me/owdding/skyocean/features/inventory/buttons/InvButtons.kt
+++ b/src/common/main/kotlin/me/owdding/skyocean/features/inventory/buttons/InvButtons.kt
@@ -62,7 +62,7 @@ object InvButtons {
         }
     }
 
-    fun onScreenBackground(screen: AbstractContainerScreen<*>, graphics: GuiGraphics) {
+    fun onScreenBackgroundAfter(screen: AbstractContainerScreen<*>, graphics: GuiGraphics) {
         if (!shouldShowButtons(screen)) return
         Screens.getButtons(screen).forEach {
             if (it is InvButton && !it.highlight) {
@@ -72,7 +72,7 @@ object InvButtons {
     }
 
     @Subscription
-    fun onScreenBackgroundEvent(event: RenderScreenBackgroundEvent) {
+    fun onScreenBackground(event: RenderScreenBackgroundEvent) {
         if (!shouldShowButtons(event.screen)) return
         Screens.getButtons(event.screen).forEach {
             if (it is InvButton && !it.highlight) {

--- a/src/common/main/kotlin/me/owdding/skyocean/features/inventory/buttons/InvButtons.kt
+++ b/src/common/main/kotlin/me/owdding/skyocean/features/inventory/buttons/InvButtons.kt
@@ -8,10 +8,10 @@ import me.owdding.skyocean.utils.ChatUtils.sendWithPrefix
 import me.owdding.skyocean.utils.OceanColors
 import me.owdding.skyocean.utils.Utils.unaryPlus
 import net.fabricmc.fabric.api.client.screen.v1.Screens
+import net.minecraft.client.gui.GuiGraphics
 import net.minecraft.client.gui.screens.Screen
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen
 import tech.thatgravyboat.skyblockapi.api.events.base.Subscription
-import tech.thatgravyboat.skyblockapi.api.events.render.RenderScreenBackgroundEvent
 import tech.thatgravyboat.skyblockapi.api.events.render.RenderScreenForegroundEvent
 import tech.thatgravyboat.skyblockapi.api.events.screen.ScreenInitializedEvent
 import tech.thatgravyboat.skyblockapi.api.location.LocationAPI
@@ -61,12 +61,11 @@ object InvButtons {
         }
     }
 
-    @Subscription
-    fun onScreenBackground(event: RenderScreenBackgroundEvent) {
-        if (!shouldShowButtons(event.screen)) return
-        Screens.getButtons(event.screen).forEach {
+    fun onScreenBackground(screen: AbstractContainerScreen<*>, graphics: GuiGraphics, mouseX: Int, mouseY: Int, delta: Float) {
+        if (!shouldShowButtons(screen)) return
+        Screens.getButtons(screen).forEach {
             if (it is InvButton && !it.highlight) {
-                it.renderButtons(event.graphics, 0, 0, 0F)
+                it.renderButtons(graphics, mouseX, mouseY, delta, true)
             }
         }
     }
@@ -76,7 +75,7 @@ object InvButtons {
         if (!shouldShowButtons(event.screen)) return
         Screens.getButtons(event.screen).forEach {
             if (it is InvButton && it.highlight) {
-                it.renderButtons(event.graphics, 0, 0, 0F)
+                it.renderButtons(event.graphics, 0, 0, 0F, false)
             }
         }
     }

--- a/src/common/main/kotlin/me/owdding/skyocean/features/inventory/buttons/InvButtons.kt
+++ b/src/common/main/kotlin/me/owdding/skyocean/features/inventory/buttons/InvButtons.kt
@@ -12,6 +12,7 @@ import net.minecraft.client.gui.GuiGraphics
 import net.minecraft.client.gui.screens.Screen
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen
 import tech.thatgravyboat.skyblockapi.api.events.base.Subscription
+import tech.thatgravyboat.skyblockapi.api.events.render.RenderScreenBackgroundEvent
 import tech.thatgravyboat.skyblockapi.api.events.render.RenderScreenForegroundEvent
 import tech.thatgravyboat.skyblockapi.api.events.screen.ScreenInitializedEvent
 import tech.thatgravyboat.skyblockapi.api.location.LocationAPI
@@ -61,11 +62,21 @@ object InvButtons {
         }
     }
 
-    fun onScreenBackground(screen: AbstractContainerScreen<*>, graphics: GuiGraphics, mouseX: Int, mouseY: Int, delta: Float) {
+    fun onScreenBackground(screen: AbstractContainerScreen<*>, graphics: GuiGraphics) {
         if (!shouldShowButtons(screen)) return
         Screens.getButtons(screen).forEach {
             if (it is InvButton && !it.highlight) {
-                it.renderButtons(graphics, mouseX, mouseY, delta, true)
+                it.renderItem(graphics)
+            }
+        }
+    }
+
+    @Subscription
+    fun onScreenBackgroundEvent(event: RenderScreenBackgroundEvent) {
+        if (!shouldShowButtons(event.screen)) return
+        Screens.getButtons(event.screen).forEach {
+            if (it is InvButton && !it.highlight) {
+                it.renderButtons(event.graphics, 0, 0, 0F)
             }
         }
     }
@@ -75,7 +86,8 @@ object InvButtons {
         if (!shouldShowButtons(event.screen)) return
         Screens.getButtons(event.screen).forEach {
             if (it is InvButton && it.highlight) {
-                it.renderButtons(event.graphics, 0, 0, 0F, false)
+                it.renderButtons(event.graphics, 0, 0, 0F)
+                it.renderItem(event.graphics)
             }
         }
     }

--- a/src/mixins/skyocean.client.mixins.json
+++ b/src/mixins/skyocean.client.mixins.json
@@ -21,6 +21,7 @@
     "MutableComponentMixin",
     "PlayerRendererMixin",
     "PlayerRenderStateMixin",
-    "ScreenAccessor"
+    "ScreenAccessor",
+    "AbstractContainerScreenMixin"
   ]
 }


### PR DESCRIPTION
As the title says, this pr fixes inventory button items rendering behind the background on 1.21.8.