### PR TITLE
feat: blacklist more recipes

### DIFF
--- a/src/common/main/kotlin/me/owdding/skyocean/features/recipe/SimpleRecipeApi.kt
+++ b/src/common/main/kotlin/me/owdding/skyocean/features/recipe/SimpleRecipeApi.kt
@@ -23,6 +23,12 @@ private val illegalIngredients = listOf(
     "SLIME_BLOCK",
     "LEATHER",
     "BLAZE_POWDER",
+    "STICK",
+    "WOOD_SWORD",
+    "WOOD_PICKAXE",
+    "WOOD_SPADE",
+    "WOOD_HOE",
+    "WOOD_AXE",
 )
 
 @LateInitModule


### PR DESCRIPTION
Minion stuff mainly, don't need to be shown how to craft these since they can be bought from the Lumber Merchant and it's common sense anyway.