### PR TITLE
build: forcibly disable configuration cache

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -281,6 +281,10 @@ repo {
 }
 
 tasks {
+    configureEach {
+        notCompatibleWithConfigurationCache("Configuration cache causes various errors in the build")
+    }
+
     withType<ProcessResources>().configureEach {
         duplicatesStrategy = DuplicatesStrategy.INCLUDE
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -282,7 +282,7 @@ repo {
 
 tasks {
     configureEach {
-        notCompatibleWithConfigurationCache("Configuration cache causes various errors in the build")
+        notCompatibleWithConfigurationCache("Configuration cache causes various build errors")
     }
 
     withType<ProcessResources>().configureEach {


### PR DESCRIPTION
In case someone has it enabled in their `~/.gradle/gradle.properties`.