### PR TITLE
feat: Make Item Search default to the rift while in the rift

### DIFF
--- a/src/common/main/kotlin/me/owdding/skyocean/features/item/search/screen/ItemSearchScreen.kt
+++ b/src/common/main/kotlin/me/owdding/skyocean/features/item/search/screen/ItemSearchScreen.kt
@@ -98,11 +98,11 @@ object ItemSearchScreen : SkyOceanScreen() {
     }
 
     override fun init() {
+        if (SkyBlockIsland.THE_RIFT.inIsland()) this.category = SearchCategory.RIFT
+
         if (requireRebuild) {
             rebuildItems()
         }
-
-        if (SkyBlockIsland.THE_RIFT.inIsland()) this.category = SearchCategory.RIFT
 
         super.init()
         val width = widgetWidth


### PR DESCRIPTION
Before
<img width="130" height="407" alt="image" src="https://github.com/user-attachments/assets/1cb5c04d-bfc8-42bb-aa4b-aa4c3d56dcc4" />
After
<img width="80" height="282" alt="image" src="https://github.com/user-attachments/assets/b2f81972-0053-4594-975a-392fea52039d" />