### PR TITLE
chore: use stonecutter annotations for hide lightning mixin

### DIFF
--- a/src/main/java/me/owdding/skyocean/mixins/features/hidelightning/LightningBoltRendererMixin.java
+++ b/src/main/java/me/owdding/skyocean/mixins/features/hidelightning/LightningBoltRendererMixin.java
@@ -11,12 +11,10 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public class LightningBoltRendererMixin {
 
     @Inject(
-        method = {
-            // 1.21.9+
-            "submit(Lnet/minecraft/client/renderer/entity/state/LightningBoltRenderState;Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/SubmitNodeCollector;Lnet/minecraft/client/renderer/state/CameraRenderState;)V",
-            // 1.21.5-1.21.8
-            "render(Lnet/minecraft/client/renderer/entity/state/LightningBoltRenderState;Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;I)V"
-        },
+        //? >=1.21.9{
+        method = "submit(Lnet/minecraft/client/renderer/entity/state/LightningBoltRenderState;Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/SubmitNodeCollector;Lnet/minecraft/client/renderer/state/CameraRenderState;)V",
+        //?} else
+        /*method = "render(Lnet/minecraft/client/renderer/entity/state/LightningBoltRenderState;Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;I)V",*/
         at = @At("HEAD"),
         cancellable = true
     )

--- a/src/main/java/me/owdding/skyocean/mixins/features/hidelightning/LightningBoltRendererMixin.java
+++ b/src/main/java/me/owdding/skyocean/mixins/features/hidelightning/LightningBoltRendererMixin.java
@@ -11,7 +11,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public class LightningBoltRendererMixin {
 
     @Inject(
-        //? >=1.21.9{
+        //? > 1.21.8 {
         method = "submit(Lnet/minecraft/client/renderer/entity/state/LightningBoltRenderState;Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/SubmitNodeCollector;Lnet/minecraft/client/renderer/state/CameraRenderState;)V",
         //?} else
         /*method = "render(Lnet/minecraft/client/renderer/entity/state/LightningBoltRenderState;Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;I)V",*/


### PR DESCRIPTION
This fixes a compiler warning:
```
> Task :1.21.10:compileJava
/Users/luna/src/SkyOcean/src/main/java/me/owdding/skyocean/mixins/features/hidelightning/LightningBoltRendererMixin.java:13: warning: Cannot find target method "render(Lnet/minecraft/client/renderer/entity/state/LightningBoltRenderState;Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;I)V" for @Inject.method="render(Lnet/minecraft/client/renderer/entity/state/LightningBoltRenderState;Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;I)V" in net.minecraft.client.renderer.entity.LightningBoltRenderer
    @Inject(
    ^
Note: /Users/luna/src/SkyOcean/versions/1.21.10/src/main/java/me/owdding/skyocean/mixins/GuiRendererMixin.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
1 warning
```