### PR TITLE
fix: Jerry's Workshop hotspots

### DIFF
--- a/src/lang/en_us.json
+++ b/src/lang/en_us.json
@@ -1199,7 +1199,7 @@
             "desc": "Render a \"solid\" outline instead of the particle outline."
           },
           "outline_transparency": {
-            "@value": "Surface Transparency",
+            "@value": "Outline Transparency",
             "desc": [
               "Changes the transparency of the outline.",
               {

--- a/src/main/kotlin/me/owdding/skyocean/api/HotspotAPI.kt
+++ b/src/main/kotlin/me/owdding/skyocean/api/HotspotAPI.kt
@@ -103,7 +103,8 @@ object HotspotAPI {
 
         val maxHotspotSize = when (LocationAPI.island) {
             SkyBlockIsland.CRIMSON_ISLE -> 25.0
-            else -> 16.0
+            SkyBlockIsland.JERRYS_WORKSHOP -> 16.0
+            else -> 9.0
         }
 
         for (entry in _hotspots.values) {

--- a/src/main/kotlin/me/owdding/skyocean/api/HotspotAPI.kt
+++ b/src/main/kotlin/me/owdding/skyocean/api/HotspotAPI.kt
@@ -103,7 +103,7 @@ object HotspotAPI {
 
         val maxHotspotSize = when (LocationAPI.island) {
             SkyBlockIsland.CRIMSON_ISLE -> 25.0
-            else -> 9.0
+            else -> 16.0
         }
 
         for (entry in _hotspots.values) {

--- a/src/main/kotlin/me/owdding/skyocean/features/fishing/HotspotFeatures.kt
+++ b/src/main/kotlin/me/owdding/skyocean/features/fishing/HotspotFeatures.kt
@@ -29,7 +29,7 @@ object HotspotFeatures {
 
     @Subscription
     @OnlyOnSkyBlock
-    fun onRenderWorldEvent(event: RenderWorldEvent.AfterTranslucent) {
+    fun onRenderWorldEvent(event: RenderWorldEvent.AfterEntities) {
         if (!isEnabled()) return
 
         HotspotAPI.hotspots.forEach { (_, type, pos, radius) ->


### PR DESCRIPTION
Fixed hotspots on Jerry's Workshop (which are underwater rather than being right on the surface) not rendering from above. Also increased the max hotspot size outside Crimson Isle because some weren't getting detected. Plus fixed a config option name.