### PR TITLE
fix(HotspotAPI): water hotspot detection

### DIFF
--- a/src/main/kotlin/me/owdding/skyocean/api/HotspotAPI.kt
+++ b/src/main/kotlin/me/owdding/skyocean/api/HotspotAPI.kt
@@ -132,10 +132,10 @@ object HotspotAPI {
         val options = this.particle as? DustParticleOptions ?: return false
         if (options.color != PARTICLE_COLOR) return false
 
-        // strict bs :-D
-        if (this.count != 1) return false
-        if (this.xDist != 0f || this.yDist != 0f || this.zDist != 0f) return false
-        if (this.maxSpeed != 0f) return false
+        // (a bit less) strict bs :-D
+        if (this.count != 0) return false
+        if (this.xDist != 1f) return false
+        if (this.maxSpeed != 1f)  return false
 
         return true
     }


### PR DESCRIPTION
Fixes broken checks introduced in bc455029 breaking detection of all water hotspots (lava/Crimson Isle hotspots were still working, this doesn't change that).