### PR TITLE
feat(HotspotFeatures): add option to keep particles

### DIFF
--- a/src/lang/en_us.json
+++ b/src/lang/en_us.json
@@ -1201,7 +1201,7 @@
           "highlight": "Highlight",
           "circle_surface": {
             "@value": "Surface",
-            "desc": "Render a \"solid\" circle instead of the particle outline."
+            "desc": "Render a \"solid\" circle for hotspots."
           },
           "surface_transparency": {
             "@value": "Surface Transparency",
@@ -1214,7 +1214,7 @@
           },
           "circle_outline": {
             "@value": "Outline",
-            "desc": "Render a \"solid\" outline instead of the particle outline."
+            "desc": "Render a \"solid\" outline for hotspots."
           },
           "outline_transparency": {
             "@value": "Outline Transparency",
@@ -1224,6 +1224,10 @@
                 "@id": "transparency"
               }
             ]
+          },
+          "hide_particles": {
+            "@value": "Hide Particles",
+            "desc": "Hide hotspot particles (requires Highlight or Outline to be enabled)."
           }
         }
       },

--- a/src/main/kotlin/me/owdding/skyocean/api/HotspotAPI.kt
+++ b/src/main/kotlin/me/owdding/skyocean/api/HotspotAPI.kt
@@ -121,7 +121,7 @@ object HotspotAPI {
         match.first.radius = sqrt(match.second).roundToHalf()
 
         // particles cancelled
-        if (HotspotFeatures.isEnabled()) event.cancel()
+        if (HotspotFeatures.shouldHideParticles()) event.cancel()
     }
 
     private fun ClientboundLevelParticlesPacket.isHotSpotParticle(): Boolean {

--- a/src/main/kotlin/me/owdding/skyocean/config/features/fishing/HotspotFeaturesConfig.kt
+++ b/src/main/kotlin/me/owdding/skyocean/config/features/fishing/HotspotFeaturesConfig.kt
@@ -23,6 +23,10 @@ object HotspotFeaturesConfig : ObjectKt() {
         this.translation = "skyocean.config.fishing.hotspot.circle_outline"
     }
 
+    var hideParticles by boolean(true) {
+        this.translation = "skyocean.config.fishing.hotspot.hide_particles"
+    }
+
     var surfaceTransparency by transparency(50) {
         this.translation = "skyocean.config.fishing.hotspot.surface_transparency"
     }

--- a/src/main/kotlin/me/owdding/skyocean/features/fishing/HotspotFeatures.kt
+++ b/src/main/kotlin/me/owdding/skyocean/features/fishing/HotspotFeatures.kt
@@ -27,6 +27,8 @@ object HotspotFeatures {
 
     fun isEnabled() = HotspotFeaturesConfig.circleOutline || HotspotFeaturesConfig.circleSurface
 
+    fun shouldHideParticles() = isEnabled() && HotspotFeaturesConfig.hideParticles
+
     @Subscription
     @OnlyOnSkyBlock
     fun onRenderWorldEvent(event: RenderWorldEvent.AfterEntities) {


### PR DESCRIPTION
Adds an option to still show hotspot particles while rendering the custom outline and/or highlight.