### PR TITLE
fix: use /stats instead of /eq to open equipment

### DIFF
--- a/src/main/kotlin/me/owdding/skyocean/features/item/sources/InventoryItemSource.kt
+++ b/src/main/kotlin/me/owdding/skyocean/features/item/sources/InventoryItemSource.kt
@@ -50,7 +50,7 @@ object EquipmentItemContext : OnPlayerItemContext {
         }
     }
 
-    override fun open() = requiresOverworld(true) { McClient.sendCommand("/eq") }
+    override fun open() = requiresOverworld(true) { McClient.sendCommand("/stats") }
 }
 
 object InventoryItemContext : OnPlayerItemContext {

--- a/src/main/kotlin/me/owdding/skyocean/features/item/sources/RiftItemSource.kt
+++ b/src/main/kotlin/me/owdding/skyocean/features/item/sources/RiftItemSource.kt
@@ -82,7 +82,7 @@ object RiftEquipment : RiftItemContext {
         requiresOverworld { add("Equipped in rift!") { color = TextColor.GRAY } }
     }
 
-    override fun open() = requiresRift(true) { McClient.sendCommand("/eq") }
+    override fun open() = requiresRift(true) { McClient.sendCommand("/stats") }
 }
 
 data class RiftEnderchestPageContext(


### PR DESCRIPTION
`/eq` and `/equipment` now open the equipment wardrobe rather than the old equipment screen.