### PR TITLE
fix(HotKeyManager): hotkeys block debug key combos

### DIFF
--- a/src/main/kotlin/me/owdding/skyocean/features/hotkeys/system/HotkeyManager.kt
+++ b/src/main/kotlin/me/owdding/skyocean/features/hotkeys/system/HotkeyManager.kt
@@ -3,7 +3,6 @@ package me.owdding.skyocean.features.hotkeys.system
 import com.google.common.collect.EvictingQueue
 import com.mojang.blaze3d.platform.InputConstants
 import com.mojang.serialization.Codec
-import earth.terrarium.olympus.client.ui.modals.Modals.action
 import me.owdding.ktcodecs.GenerateCodec
 import me.owdding.ktcodecs.IncludedCodec
 import me.owdding.ktcodecs.NamedCodec
@@ -17,7 +16,6 @@ import me.owdding.skyocean.utils.codecs.CodecHelpers
 import me.owdding.skyocean.utils.debugToggle
 import me.owdding.skyocean.utils.storage.DataStorage
 import net.minecraft.client.input.KeyEvent
-import net.minecraft.client.input.MouseButtonEvent
 import net.minecraft.client.input.MouseButtonInfo
 import net.minecraft.util.Util
 import org.lwjgl.glfw.GLFW
@@ -60,6 +58,9 @@ object HotkeyManager {
             hotkeySet.xmap({ StoredData(mutableSetOf(), it) }, { it.hotkeys }),
         ),
     )
+
+    private val options = McClient.options
+
 
     private val tree = HotkeyTree()
 
@@ -166,7 +167,8 @@ object HotkeyManager {
 
     @JvmStatic
     fun handle(event: KeyEvent, action: Int): Boolean {
-        return handleKey(lazy { InputConstants.getKey(event) }, action)
+        if (!options.keyDebugModifier.isDown) return handleKey(lazy { InputConstants.getKey(event) }, action)
+        return false
     }
 
     fun clearBuffers() {

--- a/src/main/kotlin/me/owdding/skyocean/features/hotkeys/system/HotkeyManager.kt
+++ b/src/main/kotlin/me/owdding/skyocean/features/hotkeys/system/HotkeyManager.kt
@@ -59,7 +59,7 @@ object HotkeyManager {
         ),
     )
 
-    private val options = McClient.options
+    private val options by lazy { McClient.options }
 
     private val tree = HotkeyTree()
 

--- a/src/main/kotlin/me/owdding/skyocean/features/hotkeys/system/HotkeyManager.kt
+++ b/src/main/kotlin/me/owdding/skyocean/features/hotkeys/system/HotkeyManager.kt
@@ -59,8 +59,6 @@ object HotkeyManager {
         ),
     )
 
-    private val options by lazy { McClient.options }
-
     private val tree = HotkeyTree()
 
     inline val MAX_INPUT_DELAY get() = HotkeyConfig.sequenceInputDelay
@@ -166,7 +164,7 @@ object HotkeyManager {
 
     @JvmStatic
     fun handle(event: KeyEvent, action: Int): Boolean {
-        if (!options.keyDebugModifier.isDown) return handleKey(lazy { InputConstants.getKey(event) }, action)
+        if (!McClient.options.keyDebugModifier.isDown) return handleKey(lazy { InputConstants.getKey(event) }, action)
         return false
     }
 

--- a/src/main/kotlin/me/owdding/skyocean/features/hotkeys/system/HotkeyManager.kt
+++ b/src/main/kotlin/me/owdding/skyocean/features/hotkeys/system/HotkeyManager.kt
@@ -61,7 +61,6 @@ object HotkeyManager {
 
     private val options = McClient.options
 
-
     private val tree = HotkeyTree()
 
     inline val MAX_INPUT_DELAY get() = HotkeyConfig.sequenceInputDelay


### PR DESCRIPTION
fixes hotkeys overriding debug combos making them completely inaccessible while you had a hotkey that used the same key (for example having a hotkey set to `B` would block `F3 + B`)

perhaps a warning should be added if you try making a hotkey that uses f3 (or more accurately `keyDebugModifier`).