### PR TITLE
Add 'Others' option to player animals fun setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ seamless way.
     - Configurable display types and individual custom colors for every mob icon.
 - Fun: Player Animals
     - Render players in the world as animals (Cats, Foxes, Wolves, Axolotls, Pandas, and many more).
-    - Configure who is affected (Nobody, Self, Players, Everyone).
+    - Configure who is affected (Nobody, Self, Players, Others, Everyone).
     - Customize individual appearance traits (variants, collars, baby status, sheared states).
 - Item Search
     - Customize highlight colors, highlight modes, and highlight durations.

--- a/src/lang/en_us.json
+++ b/src/lang/en_us.json
@@ -868,7 +868,7 @@
             "@value": "Player Animals",
             "desc": [
               "Changes players in the world to be rendered as the selected animal!",
-              "You can choose between <white>Nobody</white>, <white>Self</white>, <white>Players (non NPCs)</white> and <white>Everyone</white>."
+              "You can choose between <white>Nobody</white>, <white>Self</white>, <white>Players (non NPCs)</white>, <white>Others (non NPCs)</white>, and <white>Everyone</white>."
             ],
             "type": {
               "@value": "Animal Type",

--- a/src/lang/en_us.json
+++ b/src/lang/en_us.json
@@ -1394,6 +1394,7 @@
               "none": "Nobody",
               "self": "Self",
               "players": "Players",
+              "others": "Others",
               "everyone": "Everyone"
             },
             "color": {

--- a/src/main/kotlin/me/owdding/skyocean/features/misc/fun/animal/PlayerAnimals.kt
+++ b/src/main/kotlin/me/owdding/skyocean/features/misc/fun/animal/PlayerAnimals.kt
@@ -44,6 +44,7 @@ object PlayerAnimals {
             PlayerAnimalState.NONE -> false
             PlayerAnimalState.EVERYONE -> true
             PlayerAnimalState.SELF -> accessor.`skyocean$isSelf`()
+            PlayerAnimalState.OTHERS -> !accessor.`skyocean$isSelf`() && !accessor.`skyocean$isNpc`()
             PlayerAnimalState.PLAYERS -> !accessor.`skyocean$isNpc`()
         }
     }
@@ -120,7 +121,7 @@ object PlayerAnimals {
         NONE,
         SELF,
         PLAYERS,
-
+        OTHERS,
         EVERYONE,
         ;
 


### PR DESCRIPTION
This pull request adds an option to the player animals feature so that you can have other players as animals without making yourself an animal.

My brother and I both independently realized that this feature was missing, so I decided I'd look into implementing it.

I think the main part missing from these commits are translations for Russian and Chinese, so it would probably be a good idea to fix that before merging.